### PR TITLE
Avoid leftovers in the DOM after input removal

### DIFF
--- a/src/angular-elastic-input.js
+++ b/src/angular-elastic-input.js
@@ -43,6 +43,10 @@ angular.module('puElasticInput', []).directive('puElasticInput', function(){
             } else {
                 element.on('keydown keyup focus input propertychange change', function(){ update(); });
             }
+            
+            scope.$on('$destroy', function() {
+                wrapper.remove();
+            });
         }
     };
 });


### PR DESCRIPTION
This change keeps the DOM clean.