### PR TITLE
Register native event if element has ngModelOptions

### DIFF
--- a/src/angular-elastic-input.js
+++ b/src/angular-elastic-input.js
@@ -58,7 +58,7 @@ angular.module('puElasticInput', []).directive('puElasticInput', ['$document', '
 
             update();
 
-            if (attrs.ngModel) {
+            if (attrs.ngModel && !attrs.ngModelOptions) {
                 scope.$watch(attrs.ngModel, update);
             } else {
                 element.on('keydown keyup focus input propertychange change', update);


### PR DESCRIPTION
Currently , the directive registers dom events if there is no ng-model otherwise it registers scope watch .It should register a native event if the element has ngModelOptions to avoid the debounce delay.

This commit addresses issue #13.