### PR TITLE
Format the license in package.json to match the SPDX standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "autosize input",
     "autogrow input"
   ],
-  "license": "MIT License",
+  "license": "MIT",
   "author": {
     "name": "Jacek Pulit",
     "email": "jacek.pulit@gmail.com"


### PR DESCRIPTION
As documented on the NPM documentation (https://docs.npmjs.com/files/package.json#license). The license field has to comply with the SPDX specification for communicating the licenses and copyrights associated with a software package. This commit changes the license to a valid SPDX value (MIT)