### PR TITLE
Fix package json for browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "autogrow input"
   ],
   "license": "MIT License",
+  "main": "dist/angular-elastic-input.js",
   "author": {
     "name": "Jacek Pulit",
     "email": "jacek.pulit@gmail.com"


### PR DESCRIPTION
Without this fix, browserify does not recognize the module. We have to add a main key in the package.json